### PR TITLE
fix: prevent crash on telemetry HTTP failure

### DIFF
--- a/internal/service/telemetry/telemetry.go
+++ b/internal/service/telemetry/telemetry.go
@@ -52,6 +52,7 @@ func (s *Service) SendTelemetry(runtimeDuration time.Time, isShuttingDown bool, 
 	resp, err := client.Do(req)
 	if err != nil {
 		debug.Telemetry.Error("failed to send telemetry data: %+v", err)
+		return
 	}
 	defer resp.Body.Close() // nolint:errcheck
 }


### PR DESCRIPTION
Adds missing `return` after error log in `SendTelemetry()`.

Without this, TLS/network errors cause nil pointer dereference on `resp.Body.Close()` and crash the application.